### PR TITLE
Create main map 

### DIFF
--- a/prep/main_map.R
+++ b/prep/main_map.R
@@ -1,0 +1,176 @@
+
+library(tidyverse)
+library(highcharter) 
+library(sf)
+
+# https://mareichler.github.io/usahex/articles/available_maps.html
+library(usahex)
+
+box::use(
+  ./box/admin
+)
+
+
+this_path <- csgjcr::csg_sp_path("50 State Revocations Project/50 State Survey (2024)/Data/analysis/main_map")
+
+# load data --------------------------------------------------------------------
+
+data <- read_csv(file.path(
+  this_path, "Data for main map 2025_fordesigner(CATEGORIES FOR V3).csv"), 
+  skip = 1
+  ) |> 
+  filter(state_name %in% state.name) |> 
+  select(state_name, category = Category, color = ...12) |> 
+  fill(color, .direction = "down") |> 
+  mutate(
+    category = factor(category, levels = c("Staying Low", "Creeping Upward", "Back to Baseline", "Sharp Increase"))
+  ) 
+
+color_df <- data |> distinct(category, color) |> 
+  arrange(category)
+
+
+hexcoords <- usahex::get_coordinates(map = "states50", coords = "hexmap") 
+
+## OPTION 1 
+
+plotdf <- left_join(hexcoords, data, by = c("name" = "state_name"))
+
+p1 <- plotdf |> 
+  ggplot() + 
+  geom_sf(aes(fill = category), color = "#8c8c8c") + 
+  scale_fill_manual(
+    values = c("#26456E", "#C7E8F5", "#FAEC71", "#D6C246"), 
+    na.value = "#DEDEDE", 
+    name = NULL, 
+    guide = guide_legend(override.aes = list(color = "white"))
+  ) + 
+  geom_sf_text(
+    aes(label = abbr_usps, color = category), 
+    family = "Graphik", 
+    fontface = "bold", 
+    show.legend = FALSE
+  ) + 
+  scale_color_manual(
+    values = c("white", "#333333", "#333333", "#333333"), 
+    na.value = "#333333", 
+    name = NULL, 
+  ) + 
+  theme_void() + 
+  theme(
+    text = element_text(family = "Graphik"), 
+    legend.position = "top", 
+    # add this so don't have transparent background in png
+    plot.background = element_rect(fill = "white", color = "white")
+  )
+
+p1
+
+ggsave(filename = file.path(this_path, 
+    "Data for main map 2025_fordesigner(CATEGORIES FOR V3)opt1.png"), 
+    plot = p1, 
+    width = 8, 
+    height = 5.5)
+
+file.show(file.path(this_path, "Data for main map 2025_fordesigner(CATEGORIES FOR V3)opt1.png"))
+
+
+## OPTION 2
+
+p2 <- ggplot(plotdf) + 
+  geom_sf(data = filter(plotdf, !is.na(category)), aes(fill = category), color = "#8c8c8c") + 
+    geom_sf(data = filter(plotdf, is.na(category)), fill = "#DEDEDE", color = "#8c8c8c") + 
+  scale_fill_manual(
+    values = c("#26456E", "#C7E8F5", "#FAEC71", "#D6C246"), 
+    na.value = "#DEDEDE", 
+    name = NULL, 
+    guide = guide_legend(override.aes = list(color = "white"))
+  ) + 
+  geom_sf_text(
+    aes(label = abbr_usps, color = category), 
+    family = "Graphik", 
+    fontface = "bold", 
+    show.legend = FALSE
+  ) + 
+  scale_color_manual(
+    values = c("white", "#333333", "#333333", "#333333"), 
+    na.value = "#333333", 
+    name = NULL, 
+  ) + 
+  theme_void() + 
+  theme(
+    text = element_text(family = "Graphik"), 
+    legend.position = "top", 
+    # add this so don't have transparent background in png
+    plot.background = element_rect(fill = "white", color = "white")
+  )
+
+
+p2
+
+
+ggsave(filename = file.path(this_path, 
+       "Data for main map 2025_fordesigner(CATEGORIES FOR V3)opt2.png"), 
+       plot = p2, 
+       width = 8, 
+       height = 5.5)
+
+file.show(file.path(this_path, "Data for main map 2025_fordesigner(CATEGORIES FOR V3)opt2.png"))
+
+
+## OPTION 3
+
+p3 <- ggplot(plotdf) + 
+  geom_sf(data = filter(plotdf, !is.na(category)), aes(fill = category), color = "#8c8c8c") + 
+  geom_sf(data = filter(plotdf, is.na(category)),      fill = "#DEDEDE", color = "#8c8c8c") + 
+  #dummy legend for NA values, also adds lighter border around certain hexagons (appears to be contrast based)
+  geom_sf(                                             fill = NA,        aes(color = "NA")) + 
+  scale_fill_manual(
+    values = c("#26456E", "#C7E8F5", "#FAEC71", "#D6C246"), 
+    name = NULL, 
+    guide = guide_legend(override.aes = list(color = "white"))
+  ) + 
+  geom_sf_text(
+    data = filter(plotdf, category != "Staying Low" | is.na(category)), 
+    aes(label = abbr_usps), 
+    color = "#333333", 
+    family = "Graphik", 
+    fontface = "bold", 
+  ) +
+  geom_sf_text(
+    data = filter(plotdf, category == "Staying Low"), 
+    aes(label = abbr_usps), 
+    color = "white", 
+    family = "Graphik", 
+    fontface = "bold", 
+  ) +
+  scale_color_manual( #dummy legend for NA color 
+    name = "  ", 
+    values = "#DEDEDE", # color four outline 
+    labels = 'N/A', 
+  ) +
+  guides(
+    fill  = guide_legend(order = 1, override.aes = list(color = "white"))
+    , color = guide_legend(override.aes = list(fill = "#DEDEDE"))
+  ) +
+  theme_void() + 
+  theme(
+    text = element_text(family = "Graphik"), 
+    legend.position = "top", 
+    # add this so don't have transparent background in png
+    plot.background = element_rect(fill = "white", color = "white")
+  )
+
+
+p3
+
+
+ggsave(filename = file.path(this_path, 
+       "Data for main map 2025_fordesigner(CATEGORIES FOR V3)opt3.png"), 
+       plot = p3, 
+       width = 8, 
+       height = 5.5)
+
+file.show(file.path(this_path, "Data for main map 2025_fordesigner(CATEGORIES FOR V3)opt3.png"))
+
+

--- a/prep/main_map.R
+++ b/prep/main_map.R
@@ -23,7 +23,8 @@ data <- read_csv(file.path(
   select(state_name, category = Category, color = ...12) |> 
   fill(color, .direction = "down") |> 
   mutate(
-    category = factor(category, levels = c("Staying Low", "Creeping Upward", "Back to Baseline", "Sharp Increase"))
+    category = factor(category, levels = c("Staying Low", "Creeping Upward", "Back to Baseline", "Sharp Increase")), 
+    category = fct_recode(category, `Creeping Upward to Baseline` = "Creeping Upward")
   ) 
 
 color_df <- data |> distinct(category, color) |> 
@@ -67,12 +68,12 @@ p1 <- plotdf |>
 p1
 
 ggsave(filename = file.path(this_path, 
-    "Data for main map 2025_fordesigner(CATEGORIES FOR V3)opt1.png"), 
+    "main_map_opt1.png"), 
     plot = p1, 
     width = 8, 
     height = 5.5)
 
-file.show(file.path(this_path, "Data for main map 2025_fordesigner(CATEGORIES FOR V3)opt1.png"))
+file.show(file.path(this_path, "main_map_opt1.png"))
 
 
 ## OPTION 2
@@ -110,12 +111,12 @@ p2
 
 
 ggsave(filename = file.path(this_path, 
-       "Data for main map 2025_fordesigner(CATEGORIES FOR V3)opt2.png"), 
+       "main_map_opt2.png"), 
        plot = p2, 
        width = 8, 
        height = 5.5)
 
-file.show(file.path(this_path, "Data for main map 2025_fordesigner(CATEGORIES FOR V3)opt2.png"))
+file.show(file.path(this_path, "main_map_opt2.png"))
 
 
 ## OPTION 3
@@ -166,12 +167,12 @@ p3
 
 
 ggsave(filename = file.path(this_path, 
-       "Data for main map 2025_fordesigner(CATEGORIES FOR V3)opt3.png"), 
+       "main_map_opt3.png"), 
        plot = p3, 
        width = 8, 
        height = 5.5)
 
-file.show(file.path(this_path, "Data for main map 2025_fordesigner(CATEGORIES FOR V3)opt3.png"))
+file.show(file.path(this_path, "main_map_opt3.png"))
 
 
 
@@ -225,11 +226,11 @@ p4
 
 
 ggsave(filename = file.path(this_path, 
-                            "Data for main map 2025_fordesigner(CATEGORIES FOR V3)opt4.png"), 
+                            "main_map_opt4.png"), 
        plot = p4, 
        width = 8, 
        height = 5.5)
 
-file.show(file.path(this_path, "Data for main map 2025_fordesigner(CATEGORIES FOR V3)opt4.png"))
+file.show(file.path(this_path, "main_map_opt4.png"))
 
 

--- a/prep/main_map.R
+++ b/prep/main_map.R
@@ -174,3 +174,62 @@ ggsave(filename = file.path(this_path,
 file.show(file.path(this_path, "Data for main map 2025_fordesigner(CATEGORIES FOR V3)opt3.png"))
 
 
+
+
+## OPTION 4
+
+p4 <- ggplot(plotdf) + 
+  #dummy legend for NA values, also add border (put first so can add other boarders onto it )
+  geom_sf(                                                      fill = NA,        aes(color = "NA")) + 
+  geom_sf(data = filter(plotdf, category == "Staying Low"), aes(fill = category), color = "#dedede") + 
+  geom_sf(data = filter(plotdf, category != "Staying Low"), aes(fill = category), color = "#8c8c8c") + 
+  geom_sf(data = filter(plotdf, is.na(category)),               fill = "#DEDEDE", color = "#8c8c8c") + 
+  scale_fill_manual(
+    values = c("#26456E", "#C7E8F5", "#FAEC71", "#D6C246"), 
+    name = NULL, 
+    guide = guide_legend(override.aes = list(color = "white"))
+  ) + 
+  geom_sf_text(
+    data = filter(plotdf, category != "Staying Low" | is.na(category)), 
+    aes(label = abbr_usps), 
+    color = "#333333", 
+    family = "Graphik", 
+    fontface = "bold", 
+  ) +
+  geom_sf_text(
+    data = filter(plotdf, category == "Staying Low"), 
+    aes(label = abbr_usps), 
+    color = "white", 
+    family = "Graphik", 
+    fontface = "bold", 
+  ) +
+  scale_color_manual( #dummy legend for NA color 
+    name = "   ", 
+    values = "#DEDEDE", # color four outline 
+    labels = 'N/A', 
+  ) +
+  guides(
+    fill  = guide_legend(order = 1, override.aes = list(color = "white"))
+    , color = guide_legend(override.aes = list(fill = "#DEDEDE"))
+  ) +
+  theme_void() + 
+  theme(
+    text = element_text(family = "Graphik"), 
+    legend.position = "top", 
+    # add this so don't have transparent background in png
+    plot.background = element_rect(fill = "white", color = "white")
+  )
+
+
+p4
+
+
+ggsave(filename = file.path(this_path, 
+                            "Data for main map 2025_fordesigner(CATEGORIES FOR V3)opt4.png"), 
+       plot = p4, 
+       width = 8, 
+       height = 5.5)
+
+file.show(file.path(this_path, "Data for main map 2025_fordesigner(CATEGORIES FOR V3)opt4.png"))
+
+


### PR DESCRIPTION
Create hex map for main page that denotes states that are 
- Staying Low 
- Creeping Upward to Baseline 
- Back to Baseline 
- Sharp Increase 

File is on Darby's SharePoint: [Data for main map 2025_fordesigner.xlsx](https://csgorg-my.sharepoint.com/:x:/g/personal/dbaham_csg_org/EWma1IgYW4REoqpBGCoYnr0BuE6rumXx-7TCC7BUs1XnrQ?rtime=E6AvT27I3Ug) 

Download [CATEGORIES FOR V3](https://csgorg.sharepoint.com/:x:/r/sites/Team-JC-Research/_layouts/15/Doc.aspx?sourcedoc=%7BADD5985C-A76F-4981-88A2-E5AAC16690D2%7D&file=Data%20for%20main%20map%202025_fordesigner(CATEGORIES%20FOR%20V3).csv&action=default&mobileredirect=true) tab as a CSV and place into [50 State Survey (2024)/Data/analysis/main_map](https://csgorg.sharepoint.com/:x:/r/sites/Team-JC-Research/_layouts/15/Doc.aspx?sourcedoc=%7BADD5985C-A76F-4981-88A2-E5AAC16690D2%7D&file=Data%20for%20main%20map%202025_fordesigner(CATEGORIES%20FOR%20V3).csv&action=default&mobileredirect=true) folder

# Create 4 options

## Option 1: default, include NA in legend 

<img width="2400" height="1650" alt="main_map_opt1" src="https://github.com/user-attachments/assets/84f946ca-91a8-434b-bf4b-529275909737" />

## Option 2: exclude NA in legend 
<img width="2400" height="1650" alt="main_map_opt2" src="https://github.com/user-attachments/assets/5dbe0d0d-f591-46ca-a6ca-b5e789665683" />

## ⭐ Option 3: create secondary NA legend, use lighter borders around hexagons 
*this is the options picked by comms* 

<img width="2400" height="1650" alt="main_map_opt3" src="https://github.com/user-attachments/assets/9d9068d8-8206-46a4-b4ac-bf3fa256b54f" />


## Option 4: create secondary NA legend, only use lighter borders around darker hexagons 
*this one is my favorite* 

<img width="2400" height="1650" alt="main_map_opt4" src="https://github.com/user-attachments/assets/36562050-bc82-4170-9705-09f09d0f370b" />

